### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,42 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "Soccer Team": {
+        "description": "Join the varsity soccer team and compete against other schools",
+        "schedule": "Mondays, Wednesdays, Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["alex@mergington.edu", "sarah@mergington.edu"]
+        },
+        "Basketball Club": {
+        "description": "Practice basketball skills and participate in friendly matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+        },
+        "Art Studio": {
+        "description": "Express creativity through painting, drawing, and sculpture",
+        "schedule": "Wednesdays, 3:30 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["lily@mergington.edu", "mia@mergington.edu"]
+        },
+        "Drama Club": {
+        "description": "Participate in theatrical productions and improve acting skills",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["noah@mergington.edu"]
+        },
+        "Debate Team": {
+        "description": "Develop critical thinking and public speaking through competitive debates",
+        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["ava@mergington.edu", "william@mergington.edu"]
+        },
+        "Science Olympiad": {
+        "description": "Compete in science and engineering challenges at regional competitions",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ethan@mergington.edu"]
+        },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -62,6 +98,10 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+    
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is registered
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not registered for this activity")
+    
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsList = details.participants.length > 0
+          ? `<ul class="participants-list">${details.participants.map(email => `<li>${email}</li>`).join('')}</ul>`
+          : '<p class="no-participants">No participants yet</p>';
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-header"><strong>Participants:</strong></p>
+            ${participantsList}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft = details.max_participants - details.participants.length;
 
         const participantsList = details.participants.length > 0
-          ? `<ul class="participants-list">${details.participants.map(email => `<li>${email}</li>`).join('')}</ul>`
+          ? `<ul class="participants-list">${details.participants.map(email => `<li>${email}<span class="delete-icon" data-activity="${name}" data-email="${email}" title="Remove participant">✕</span></li>`).join('')}</ul>`
           : '<p class="no-participants">No participants yet</p>';
 
         activityCard.innerHTML = `
@@ -70,6 +70,9 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        
+        // Refresh activities list to show new participant
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -86,6 +89,52 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle delete participant clicks
+  activitiesList.addEventListener("click", async (event) => {
+    if (event.target.classList.contains("delete-icon")) {
+      const activity = event.target.dataset.activity;
+      const email = event.target.dataset.email;
+
+      if (!confirm(`Are you sure you want to remove ${email} from ${activity}?`)) {
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        const result = await response.json();
+
+        if (response.ok) {
+          // Refresh activities list
+          await fetchActivities();
+          
+          messageDiv.textContent = result.message;
+          messageDiv.className = "success";
+          messageDiv.classList.remove("hidden");
+
+          // Hide message after 5 seconds
+          setTimeout(() => {
+            messageDiv.classList.add("hidden");
+          }, 5000);
+        } else {
+          messageDiv.textContent = result.detail || "Failed to remove participant";
+          messageDiv.className = "error";
+          messageDiv.classList.remove("hidden");
+        }
+      } catch (error) {
+        messageDiv.textContent = "Failed to remove participant. Please try again.";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+        console.error("Error removing participant:", error);
+      }
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -86,15 +86,34 @@ section h3 {
 }
 
 .participants-list {
-  list-style-type: disc;
-  padding-left: 25px;
+  list-style-type: none;
+  padding-left: 0;
   margin: 0;
 }
 
 .participants-list li {
-  padding: 3px 0;
+  padding: 8px 0;
   color: #555;
   font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.delete-icon {
+  cursor: pointer;
+  color: #c62828;
+  font-weight: bold;
+  padding: 2px 8px;
+  border-radius: 3px;
+  transition: all 0.2s;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.delete-icon:hover {
+  background-color: #ffebee;
+  transform: scale(1.1);
 }
 
 .no-participants {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,36 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-header {
+  margin-bottom: 10px;
+  color: #1a237e;
+}
+
+.participants-list {
+  list-style-type: disc;
+  padding-left: 25px;
+  margin: 0;
+}
+
+.participants-list li {
+  padding: 3px 0;
+  color: #555;
+  font-size: 14px;
+}
+
+.no-participants {
+  color: #999;
+  font-style: italic;
+  font-size: 14px;
+  margin: 0;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,264 @@
+"""
+Tests for the Mergington High School Activities API
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Add src directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from app import app, activities
+
+
+@pytest.fixture
+def client():
+    """Create a test client"""
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset activities data before each test"""
+    # Store original state
+    original_activities = {
+        name: {
+            "description": details["description"],
+            "schedule": details["schedule"],
+            "max_participants": details["max_participants"],
+            "participants": details["participants"].copy()
+        }
+        for name, details in activities.items()
+    }
+    
+    yield
+    
+    # Restore original state after test
+    for name in activities:
+        activities[name]["participants"] = original_activities[name]["participants"].copy()
+
+
+class TestRootEndpoint:
+    """Tests for the root endpoint"""
+    
+    def test_root_redirects_to_index(self, client):
+        """Test that root path redirects to static index.html"""
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/static/index.html"
+
+
+class TestGetActivities:
+    """Tests for GET /activities endpoint"""
+    
+    def test_get_activities_returns_all_activities(self, client):
+        """Test that all activities are returned"""
+        response = client.get("/activities")
+        assert response.status_code == 200
+        
+        data = response.json()
+        assert isinstance(data, dict)
+        assert len(data) > 0
+        
+        # Check structure of first activity
+        first_activity = list(data.values())[0]
+        assert "description" in first_activity
+        assert "schedule" in first_activity
+        assert "max_participants" in first_activity
+        assert "participants" in first_activity
+    
+    def test_get_activities_includes_expected_activities(self, client):
+        """Test that expected activities are present"""
+        response = client.get("/activities")
+        data = response.json()
+        
+        expected_activities = ["Soccer Team", "Basketball Club", "Art Studio", 
+                              "Drama Club", "Debate Team", "Science Olympiad"]
+        
+        for activity_name in expected_activities:
+            assert activity_name in data
+
+
+class TestSignupForActivity:
+    """Tests for POST /activities/{activity_name}/signup endpoint"""
+    
+    def test_signup_new_participant_success(self, client):
+        """Test successful signup of a new participant"""
+        response = client.post(
+            "/activities/Soccer Team/signup",
+            params={"email": "newstudent@mergington.edu"}
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "newstudent@mergington.edu" in data["message"]
+        assert "Soccer Team" in data["message"]
+        
+        # Verify participant was added
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert "newstudent@mergington.edu" in activities_data["Soccer Team"]["participants"]
+    
+    def test_signup_duplicate_participant_fails(self, client):
+        """Test that signing up the same participant twice fails"""
+        email = "duplicate@mergington.edu"
+        
+        # First signup should succeed
+        response1 = client.post(
+            "/activities/Chess Club/signup",
+            params={"email": email}
+        )
+        assert response1.status_code == 200
+        
+        # Second signup should fail
+        response2 = client.post(
+            "/activities/Chess Club/signup",
+            params={"email": email}
+        )
+        assert response2.status_code == 400
+        assert "already signed up" in response2.json()["detail"].lower()
+    
+    def test_signup_nonexistent_activity_fails(self, client):
+        """Test that signing up for non-existent activity fails"""
+        response = client.post(
+            "/activities/Nonexistent Club/signup",
+            params={"email": "student@mergington.edu"}
+        )
+        
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+    
+    def test_signup_activity_with_spaces_in_name(self, client):
+        """Test signup for activity with spaces in name"""
+        response = client.post(
+            "/activities/Drama Club/signup",
+            params={"email": "drama@mergington.edu"}
+        )
+        
+        assert response.status_code == 200
+        
+        # Verify participant was added
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert "drama@mergington.edu" in activities_data["Drama Club"]["participants"]
+
+
+class TestUnregisterFromActivity:
+    """Tests for DELETE /activities/{activity_name}/unregister endpoint"""
+    
+    def test_unregister_existing_participant_success(self, client):
+        """Test successful unregistration of an existing participant"""
+        # First, add a participant
+        client.post(
+            "/activities/Art Studio/signup",
+            params={"email": "artist@mergington.edu"}
+        )
+        
+        # Now unregister them
+        response = client.delete(
+            "/activities/Art Studio/unregister",
+            params={"email": "artist@mergington.edu"}
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "artist@mergington.edu" in data["message"]
+        assert "Art Studio" in data["message"]
+        
+        # Verify participant was removed
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert "artist@mergington.edu" not in activities_data["Art Studio"]["participants"]
+    
+    def test_unregister_non_registered_participant_fails(self, client):
+        """Test that unregistering a non-registered participant fails"""
+        response = client.delete(
+            "/activities/Basketball Club/unregister",
+            params={"email": "notregistered@mergington.edu"}
+        )
+        
+        assert response.status_code == 400
+        assert "not registered" in response.json()["detail"].lower()
+    
+    def test_unregister_from_nonexistent_activity_fails(self, client):
+        """Test that unregistering from non-existent activity fails"""
+        response = client.delete(
+            "/activities/Fake Club/unregister",
+            params={"email": "student@mergington.edu"}
+        )
+        
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+    
+    def test_unregister_preexisting_participant(self, client):
+        """Test unregistering a participant that was already in the system"""
+        # alex@mergington.edu is pre-registered for Soccer Team
+        response = client.delete(
+            "/activities/Soccer Team/unregister",
+            params={"email": "alex@mergington.edu"}
+        )
+        
+        assert response.status_code == 200
+        
+        # Verify participant was removed
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert "alex@mergington.edu" not in activities_data["Soccer Team"]["participants"]
+
+
+class TestActivityCapacity:
+    """Tests for activity participant capacity management"""
+    
+    def test_activity_has_max_participants_field(self, client):
+        """Test that activities have max_participants field"""
+        response = client.get("/activities")
+        data = response.json()
+        
+        for activity_name, details in data.items():
+            assert "max_participants" in details
+            assert isinstance(details["max_participants"], int)
+            assert details["max_participants"] > 0
+
+
+class TestEndToEndWorkflow:
+    """End-to-end workflow tests"""
+    
+    def test_signup_and_unregister_workflow(self, client):
+        """Test complete workflow of signup and unregister"""
+        email = "workflow@mergington.edu"
+        activity = "Programming Class"
+        
+        # Get initial state
+        initial_response = client.get("/activities")
+        initial_data = initial_response.json()
+        initial_count = len(initial_data[activity]["participants"])
+        
+        # Sign up
+        signup_response = client.post(
+            f"/activities/{activity}/signup",
+            params={"email": email}
+        )
+        assert signup_response.status_code == 200
+        
+        # Verify signup
+        after_signup = client.get("/activities")
+        after_signup_data = after_signup.json()
+        assert len(after_signup_data[activity]["participants"]) == initial_count + 1
+        assert email in after_signup_data[activity]["participants"]
+        
+        # Unregister
+        unregister_response = client.delete(
+            f"/activities/{activity}/unregister",
+            params={"email": email}
+        )
+        assert unregister_response.status_code == 200
+        
+        # Verify unregister
+        after_unregister = client.get("/activities")
+        after_unregister_data = after_unregister.json()
+        assert len(after_unregister_data[activity]["participants"]) == initial_count
+        assert email not in after_unregister_data[activity]["participants"]


### PR DESCRIPTION
This pull request adds participant management features to the activities app, including the ability to unregister students from activities, display and remove participants from the frontend, and introduces a comprehensive test suite for the API. The changes enhance both backend and frontend functionality, improve user experience, and ensure reliability through automated testing.

**Backend enhancements:**

* Added an endpoint to allow students to unregister from activities, including validation for activity existence and participant registration. (`src/app.py`)
* Improved signup logic to prevent duplicate registrations by checking if a student is already signed up for an activity. (`src/app.py`)
* Expanded the in-memory `activities` database with more sample activities and participants for testing and demonstration. (`src/app.py`)

**Frontend improvements:**

* Updated the activities list UI to display current participants for each activity, including a delete icon next to each participant for easy removal. (`src/static/app.js`, `src/static/styles.css`) [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R23-R35) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R125)
* Implemented frontend logic to handle participant removal via the delete icon, including confirmation prompts, API calls to unregister, and UI refresh upon changes. (`src/static/app.js`) [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R95-R140) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R73-R75)

**Testing and reliability:**

* Introduced a new test suite using `pytest` and FastAPI’s `TestClient` to cover all major API endpoints, edge cases, and end-to-end workflows. (`tests/test_api.py`, `tests/__init__.py`) [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R1-R264) [[2]](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dR1)